### PR TITLE
Runs against nightly build v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "librespot-protocol"
 version = "0.1.0"
 dependencies = [
- "mod_path 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mod_path 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "mod_path"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -174,7 +174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "protobuf_macros"
 version = "0.1.0"
-source = "git+https://github.com/plietar/rust-protobuf-macros.git#2b6a8129e015945300cb2bb7efae2ed78042ed48"
+source = "git+https://github.com/plietar/rust-protobuf-macros.git#4f4a16e3e643caf0566ca0a97d65b46b509ee542"
 
 [[package]]
 name = "rand"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ You will also need the protobuf compiler, and the
 [rust-protobuf](https://github.com/stepancheg/rust-protobuf) plugin.
 `protoc-gen-rust` must be in your `$PATH`.
 
+Also required is an installation of [portaudio](http://portaudio.com/), which
+can be installed via `brew install portaudio` for an OS X machine.
+
 Once you've cloned this repository you can build *librespot* using `cargo`.
 ```shell
 cargo build

--- a/cache/.gitignore
+++ b/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Paul Liétar <paul@lietar.net>"]
 build = "build.rs"
 
 [dependencies]
-mod_path = "~0.1.5"
+mod_path = "~0.1.6"
 protobuf = "~1.0.4"
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -76,7 +76,7 @@ impl PlayerInternal {
     fn run(self) {
         portaudio::initialize().unwrap();
 
-        let stream = portaudio::stream::Stream::<i16>::open_default(
+        let stream = portaudio::stream::Stream::<i16, i16>::open_default(
                 0, 2, 44100.0,
                 portaudio::stream::FRAMES_PER_BUFFER_UNSPECIFIED,
                 None


### PR DESCRIPTION
A couple of changes that fixes build issues against the latest nightly build.
- Bumps `mod_path` to latest version, fixing issue about not find package in rust Registry
- Adds requirement for `portaudio` to the README
- Changes initialization of the `portaudio::stream::Stream` object to specify output of stream also, in keeping with the current `portaudio` api

Let me know if any of this doesn't make sense!
