### PR TITLE
Use canonical username when subscribing to spirc.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,7 @@ fn main() {
         device_id: name.clone(),
         cache_location: PathBuf::from(cache_location)
     };
+
     let session = Session::new(config);
     session.login(username.clone(), password);
     session.poll();
@@ -76,7 +77,7 @@ fn main() {
 
     let player = Player::new(&session);
 
-    let mut spirc_manager = SpircManager::new(&session, player, username, name);
+    let mut spirc_manager = SpircManager::new(&session, player, name);
     spirc_manager.run();
 }
 


### PR DESCRIPTION
When authentication succeeds, Spotify replies with an APWelcome message. This message includes 
a canonical username field that is an uncapitalised version (with maybe some more changes) of the username entered by the user. 

SpircManager now uses the canonical username that APWelcome message
contains once authenticated instead of the username 
provided by user. SpircManager accesses it via its Session field.
