### PR TITLE
try reading password from env variable first

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::io::{stdout, Read, Write};
 use std::path::Path;
 use std::thread;
 use std::path::PathBuf;
+use std::env;
 
 use getopts::Options;
 use rpassword::read_password;
@@ -16,6 +17,8 @@ use librespot::session::{Config, Session};
 use librespot::util::version::version_string;
 use librespot::player::Player;
 use librespot::spirc::SpircManager;
+
+static PASSWORD_ENV_NAME: &'static str = "SPOTIFY_PASSWORD";
 
 fn usage(program: &str, opts: &Options) -> String {
     let brief = format!("Usage: {} [options]", program);
@@ -29,7 +32,6 @@ fn main() {
     let mut opts = Options::new();
     opts.reqopt("a", "appkey", "Path to a spotify appkey", "APPKEY");
     opts.reqopt("u", "username", "Username to sign in with", "USERNAME");
-    opts.optopt("p", "password", "Password (optional)", "PASSWORD");
     opts.reqopt("c", "cache", "Path to a directory where files will be cached.", "CACHE");
     opts.reqopt("n", "name", "Device name", "NAME");
     let matches = match opts.parse(&args[1..]) {
@@ -48,11 +50,14 @@ fn main() {
     let cache_location = matches.opt_str("c").unwrap();
     let name = matches.opt_str("n").unwrap();
 
-    let password = matches.opt_str("p").unwrap_or_else(|| {
-        print!("Password: "); 
-        stdout().flush().unwrap();
-        read_password().unwrap()
-    });
+    let password: String = match env::var(PASSWORD_ENV_NAME) {
+        Ok(val) => val,
+        Err(_) => {
+            print!("Password not found in env var {}, please enter: ", PASSWORD_ENV_NAME);
+            stdout().flush().unwrap();
+            read_password().unwrap()
+        }
+    };
 
     let mut appkey = Vec::new();
     appkey_file.read_to_end(&mut appkey).unwrap();


### PR DESCRIPTION
I don't like to appear my Spotify password in `ps` process listing, but still be able to enter it non-interactively so I can start librespot as daemon (e.g. via `systemd`).
So try reading password from environment variable `SPOTIFY_PASSWORD` first, else query interactively

In future, configuration could also be loaded from a file.
