### PR TITLE
use a more descriptive binary name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "librespot"
 path = "src/lib.rs"
 
 [[bin]]
-name = "main"
+name = "librespot"
 path = "src/main.rs"
 
 [dependencies.librespot-protocol]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cargo build
 A sample program implementing a headless Spotify Connect receiver is provided.
 Once you've built *librespot*, run it using :
 ```shell
-target/debug/main -a APPKEY -u USERNAME -c CACHEDIR -n DEVICENAME
+target/debug/librespot -a APPKEY -u USERNAME -c CACHEDIR -n DEVICENAME
 ```
 where `APPKEY` is the path to a Spotify application key file, `USERNAME` is your
 Spotify username, `CACHEDIR` is the path to directory where data will be cached,


### PR DESCRIPTION
cargo can install directly from github, use
`cargo install --git https://github.com/plietar/librespot`
binary is put to ~/.cargo/bin/
