### PR TITLE
Next/prev, volume and a bug

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,6 @@ fn usage(program: &str, opts: &Options) -> String {
 }
 
 fn main() {
-		println!("{:?}",i16::max_value());
     let args: Vec<String> = std::env::args().collect();
     let program = args[0].clone();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ fn usage(program: &str, opts: &Options) -> String {
 }
 
 fn main() {
+		println!("{:?}",i16::max_value());
     let args: Vec<String> = std::env::args().collect();
     let program = args[0].clone();
 

--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -25,7 +25,6 @@ pub struct SpircManager<D: SpircDelegate> {
 
     repeat: bool,
     shuffle: bool,
-    volume: u16,
 
     is_active: bool,
     became_active_at: i64,
@@ -44,7 +43,7 @@ pub trait SpircDelegate {
     fn play(&self);
     fn pause(&self);
     fn seek(&self, position_ms: u32);
-    fn volume(&self, vol:u16);
+    fn volume(&self, vol:i32);
     fn stop(&self);
 
     fn state(&self) -> MutexGuard<Self::State>;
@@ -56,6 +55,7 @@ pub trait SpircState {
     fn position(&self) -> (u32, i64);
     fn update_time(&self) -> i64;
     fn end_of_track(&self) -> bool;
+    fn volume(&self) -> u32;
 }
 
 impl<D: SpircDelegate> SpircManager<D> {
@@ -78,7 +78,6 @@ impl<D: SpircDelegate> SpircManager<D> {
 
             repeat: false,
             shuffle: false,
-            volume:	32767,
 
             is_active: false,
             became_active_at: 0,
@@ -192,9 +191,7 @@ impl<D: SpircDelegate> SpircManager<D> {
                 }
             }
             protocol::spirc::MessageType::kMessageTypeVolume =>{
-            	println!("{:?}",frame.get_volume());
-            	self.volume=frame.get_volume() as u16;
-            	self.delegate.volume(self.volume);
+            	self.delegate.volume(frame.get_volume() as i32);
             }
             _ => (),
         }
@@ -266,7 +263,7 @@ impl<D: SpircDelegate> SpircManager<D> {
             sw_version: version_string(),
             is_active: self.is_active,
             can_play: self.can_play,
-            volume: self.volume as u32,
+            volume: self.delegate.state().volume(),
             name: self.name.clone(),
             error_code: 0,
             became_active_at: if self.is_active { self.became_active_at as i64 } else { 0 },

--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -44,6 +44,7 @@ pub trait SpircDelegate {
     fn play(&self);
     fn pause(&self);
     fn seek(&self, position_ms: u32);
+    fn volume(&self, vol:u16);
     fn stop(&self);
 
     fn state(&self) -> MutexGuard<Self::State>;
@@ -77,7 +78,7 @@ impl<D: SpircDelegate> SpircManager<D> {
 
             repeat: false,
             shuffle: false,
-            volume: 0x8000,
+            volume:	32767,
 
             is_active: false,
             became_active_at: 0,
@@ -189,6 +190,11 @@ impl<D: SpircDelegate> SpircManager<D> {
                     self.is_active = false;
                     self.delegate.stop();
                 }
+            }
+            protocol::spirc::MessageType::kMessageTypeVolume =>{
+            	println!("{:?}",frame.get_volume());
+            	self.volume=frame.get_volume() as u16;
+            	self.delegate.volume(self.volume);
             }
             _ => (),
         }

--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -156,6 +156,7 @@ impl<D: SpircDelegate> SpircManager<D> {
                 self.tracks = frame.get_state()
                                    .get_track()
                                    .iter()
+                                   .filter(|track| track.get_gid().len()==16)
                                    .map(|track| SpotifyId::from_raw(track.get_gid()))
                                    .collect();
 
@@ -169,6 +170,16 @@ impl<D: SpircDelegate> SpircManager<D> {
             }
             protocol::spirc::MessageType::kMessageTypePause => {
                 self.delegate.pause();
+            }
+            protocol::spirc::MessageType::kMessageTypeNext => {
+            	self.index = (self.index + 1) % self.tracks.len() as u32;
+                let track = self.tracks[self.index as usize];
+                self.delegate.load(track, true, 0);
+            }
+            protocol::spirc::MessageType::kMessageTypePrev => {
+            	self.index = (self.index - 1) % self.tracks.len() as u32;
+                let track = self.tracks[self.index as usize];
+                self.delegate.load(track, true, 0);
             }
             protocol::spirc::MessageType::kMessageTypeSeek => {
                 self.delegate.seek(frame.get_position());


### PR DESCRIPTION
Added next/prev and volume integration
Solved a bug, lists that contained a track that are not allowed to be played on my phone would crash librespot. Now Librespot simply neglects these tracks in the list.

Great work with the library btw!

ps. The volume integration is sort of POC, could be optimized i guess.
