### PR TITLE
Add an option to disable internal volume control

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,8 @@ fn main() {
         .optopt("p", "password", "Password (optional)", "PASSWORD")
         .reqopt("c", "cache", "Path to a directory where files will be cached.", "CACHE")
         .reqopt("n", "name", "Device name", "NAME")
-        .optopt("b", "bitrate", "Bitrate (96, 160 or 320). Defaults to 160", "BITRATE");
+        .optopt("b", "bitrate", "Bitrate (96, 160 or 320). Defaults to 160", "BITRATE")
+        .optflag("d", "disable-volume", "Disable volume control");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -85,6 +86,7 @@ fn main() {
         device_name: name,
         cache_location: PathBuf::from(cache_location),
         bitrate: bitrate,
+        disable_volume: matches.opt_present("d"),
     };
 
     let session = Session::new(config);

--- a/src/player.rs
+++ b/src/player.rs
@@ -247,14 +247,17 @@ impl PlayerInternal {
             if self.state.lock().unwrap().status == PlayStatus::kPlayStatusPlay {
                 match decoder.as_mut().unwrap().packets().next() {
                     Some(Ok(packet)) => {
-                        let buffer = packet.data
+                        let buffer = match self.session.0.config.disable_volume {
+                            false => packet.data
                                            .iter()
                                            .map(|&x| {
                                                (x as i32
                                                 * self.state.lock().unwrap().volume as i32
                                                 / 0xFFFF) as i16
                                            })
-                                           .collect::<Vec<i16>>();
+                                           .collect::<Vec<i16>>(),
+                            true => packet.data,
+                        };
                         match stream.write(&buffer) {
                             Ok(_) => (),
                             Err(portaudio::PaError::OutputUnderflowed) => eprintln!("Underflow"),

--- a/src/session.rs
+++ b/src/session.rs
@@ -34,6 +34,7 @@ pub struct Config {
     pub device_name: String,
     pub cache_location: PathBuf,
     pub bitrate: Bitrate,
+    pub disable_volume: bool,
 }
 
 pub struct SessionData {


### PR DESCRIPTION
Reasons:
- The volume control as is embedded now is not very performant, it almost doubles CPU usage on my Raspberry Pi (but it is still low enough even on RPi 1 to not underflow)
- Some persons (including me) control volume on an external amplifier and always want to feed it 100% line level, so they do not want to change volume on the source.
  Thank you
