### PR TITLE
Add support for using librespot as a remote control

### DIFF
--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -113,6 +113,38 @@ impl SpircManager {
     pub fn devices(&self) -> HashMap<String, String> {
         self.0.lock().unwrap().devices.clone()
     }
+
+    pub fn send_play(&mut self, recipient: &str) {
+        let mut internal = self.0.lock().unwrap();
+        send_cmd(&mut *internal,
+                 protocol::spirc::MessageType::kMessageTypePlay,
+                 Some(recipient),
+                 None);
+    }
+
+    pub fn send_pause(&mut self, recipient: &str) {
+        let mut internal = self.0.lock().unwrap();
+        send_cmd(&mut *internal,
+                 protocol::spirc::MessageType::kMessageTypePause,
+                 Some(recipient),
+                 None);
+    }
+
+    pub fn send_prev(&mut self, recipient: &str) {
+        let mut internal = self.0.lock().unwrap();
+        send_cmd(&mut *internal,
+                 protocol::spirc::MessageType::kMessageTypePrev,
+                 Some(recipient),
+                 None);
+    }
+
+    pub fn send_next(&mut self, recipient: &str) {
+        let mut internal = self.0.lock().unwrap();
+        send_cmd(&mut *internal,
+                 protocol::spirc::MessageType::kMessageTypeNext,
+                 Some(recipient),
+                 None);
+    }
 }
 
 impl SpircInternal {

--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use protocol;
 pub use protocol::spirc::{PlayStatus, MessageType};
 
+#[derive(Clone)]
 pub struct SpircManager(Arc<Mutex<SpircInternal>>);
 
 struct SpircInternal {

--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -169,6 +169,10 @@ impl SpircManager {
             .state(state)
             .send();
     }
+
+    pub fn get_queue(&self) -> Vec<SpotifyId> {
+        self.0.lock().unwrap().tracks.clone()
+    }
 }
 
 impl SpircInternal {

--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -109,6 +109,10 @@ impl SpircManager {
             self.0.lock().unwrap().handle(frame);
         }
     }
+
+    pub fn devices(&self) -> HashMap<String, String> {
+        self.0.lock().unwrap().devices.clone()
+    }
 }
 
 impl SpircInternal {


### PR DESCRIPTION
This PR adds some functions to make librespot useful for controlling other Spotify Connect devices. I also solved the duplicated `notify` and `notify_with_player_state` code while I was at it.

I intend to work a it more on this, but I think the basic functionality is working and I wanted to create a PR before I accumulated to much code to review.

I'm not entirely sure if the way I detect devices connecting/disconnecting is correct, I haven't analysed the protocol that thoroughly, but it seems to work for me.
