### PR TITLE
Allow building without default cache support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hyper           = { version = "0.9.1", default-features = false }
 #json_macros     = "~0.3.0"
 lazy_static     = "~0.2.0"
 linear-map      = "1.0"
-lmdb-rs         = "0.7.0"
+lmdb-rs         = { version = "0.7.0", optional = true }
 num             = "~0.1.30"
 protobuf        = "~1.0.15"
 rand            = "~0.3.13"
@@ -66,8 +66,9 @@ serde_codegen   = { version = "0.7", optional = true }
 with-syntex       = ["serde_codegen", "protobuf_macros/with-syntex", "json_macros/with-syntex"]
 nightly           = ["serde_macros"]
 
+with-cache        = ["lmdb-rs"]
 with-tremor       = ["tremor"]
 facebook          = ["hyper/ssl", "openssl"]
 portaudio-backend = ["portaudio"]
 pulseaudio-backend= ["libpulse-sys"]
-default           = ["with-syntex", "portaudio-backend"]
+default           = ["with-cache", "with-syntex", "portaudio-backend"]

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -23,5 +23,7 @@ pub trait Cache {
 pub struct NoCache;
 impl Cache for NoCache { }
 
+#[cfg(feature = "with-cache")]
 mod default_cache;
+#[cfg(feature = "with-cache")]
 pub use self::default_cache::DefaultCache;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ extern crate eventual;
 extern crate getopts;
 extern crate hyper;
 extern crate linear_map;
-extern crate lmdb_rs;
 extern crate mdns;
 extern crate num;
 extern crate protobuf;
@@ -34,6 +33,9 @@ extern crate url;
 
 #[macro_use]
 extern crate log;
+
+#[cfg(feature = "with-cache")]
+extern crate lmdb_rs;
 
 #[cfg(not(feature = "with-tremor"))]
 extern crate vorbis;


### PR DESCRIPTION
If caching is not desired this allows us to build librespot without the `lmdb_rs` dependency.

Closes: #96 
