### PR TITLE
Fix latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,7 +564,7 @@ dependencies = [
 [[package]]
 name = "portaudio"
 version = "0.2.0"
-source = "git+https://github.com/mvdnes/portaudio-rs#0b228f54a16814c52ba1ef449ac439af59f8cab0"
+source = "git+https://github.com/mvdnes/portaudio-rs#2e1630843551a229bfe6cae6291fd157349bad60"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "portaudio_sys"
 version = "0.1.1"
-source = "git+https://github.com/mvdnes/portaudio-rs#0b228f54a16814c52ba1ef449ac439af59f8cab0"
+source = "git+https://github.com/mvdnes/portaudio-rs#2e1630843551a229bfe6cae6291fd157349bad60"
 dependencies = [
  "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/audio_backend/portaudio.rs
+++ b/src/audio_backend/portaudio.rs
@@ -1,6 +1,7 @@
 use super::{Open, Sink};
 use std::io;
 use std::process::exit;
+use std::time::Duration;
 use portaudio;
 use portaudio::device::{DeviceIndex, DeviceInfo, get_default_output_index};
 
@@ -53,12 +54,16 @@ impl <'a> Open for PortAudioSink<'a> {
             None => get_default_output_index(),
         }.expect("Could not find device");
 
+        let info = portaudio::device::get_info(device_idx);
+        let latency = match info {
+            Some(info) => info.default_high_output_latency,
+            None => Duration::new(0, 0),
+        };
+
         let params = StreamParameters {
             device: device_idx,
             channel_count: 2,
-            // Super hacky workaround the fact that Duration is private
-            // in portaudio
-            suggested_latency: unsafe { ::std::mem::transmute(0i64) },
+            suggested_latency: latency,
             data: 0i16,
         };
 


### PR DESCRIPTION
Specify suggested_latency from device info. This is the same behavior as when previously using Stream::open_default() before 1396f97. Using the default high output latency ensures robust playback. This fixes #102.
