### PR TITLE
close stream on stop

### DIFF
--- a/src/audio_backend/mod.rs
+++ b/src/audio_backend/mod.rs
@@ -5,9 +5,9 @@ pub trait Open {
 }
 
 pub trait Sink {
-    fn start(&self) -> io::Result<()>;
-    fn stop(&self) -> io::Result<()>;
-    fn write(&self, data: &[i16]) -> io::Result<()>;
+    fn start(&mut self) -> io::Result<()>;
+    fn stop(&mut self) -> io::Result<()>;
+    fn write(&mut self, data: &[i16]) -> io::Result<()>;
 }
 
 /*

--- a/src/audio_backend/pulseaudio.rs
+++ b/src/audio_backend/pulseaudio.rs
@@ -43,15 +43,15 @@ impl Open for PulseAudioSink {
 }
 
 impl Sink for PulseAudioSink {
-    fn start(&self) -> io::Result<()> {
+    fn start(&mut self) -> io::Result<()> {
         Ok(())
     }
 
-    fn stop(&self) -> io::Result<()> {
+    fn stop(&mut self) -> io::Result<()> {
         Ok(())
     }
 
-    fn write(&self, data: &[i16]) -> io::Result<()> {
+    fn write(&mut self, data: &[i16]) -> io::Result<()> {
         unsafe {
             let ptr = transmute(data.as_ptr());
             let bytes = data.len() as usize * 2;

--- a/src/player.rs
+++ b/src/player.rs
@@ -213,7 +213,7 @@ fn load_track(session: &Session, track_id: SpotifyId) -> Option<vorbis::Decoder<
 }
 
 impl PlayerInternal {
-    fn run(self, sink: Box<Sink>) {
+    fn run(self, mut sink: Box<Sink>) {
         let mut decoder = None;
 
         loop {


### PR DESCRIPTION
After playback is stopped librespot does not release the audio device making it impossible for other processes to require the audio stream without killing librespot.

@herrernst proposed this solution for the portaudio backend.

Closes #26 
