### PR TITLE
Fix out of bounds panic

### DIFF
--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -209,11 +209,14 @@ impl SpircInternal {
                 }
 
                 self.reload_tracks(&frame);
-
-                let play = frame.get_state().get_status() == PlayStatus::kPlayStatusPlay;
-                let track = self.tracks[self.index as usize];
-                let position = frame.get_state().get_position_ms();
-                self.player.load(track, play, position);
+                if self.tracks.len() > 0 {
+                    let play = frame.get_state().get_status() == PlayStatus::kPlayStatusPlay;
+                    let track = self.tracks[self.index as usize];
+                    let position = frame.get_state().get_position_ms();
+                    self.player.load(track, play, position);
+                } else {
+                    self.notify(false, Some(frame.get_ident()));
+                }
             }
             MessageType::kMessageTypePlay => {
                 self.player.play();


### PR DESCRIPTION
Selecting a librespot device with the Spotify desktop client causes a
crash if the playlist is empty.

Take into account the case where an empty list of tracks is received. In
this case notify the desktop client, so it will accept the device and
turn the status bar green.

Closes: #71
