### PR TITLE
Add --on{start,stop} command line option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ fn main() {
     main_helper::add_session_arguments(&mut opts);
     main_helper::add_authentication_arguments(&mut opts);
     main_helper::add_player_arguments(&mut opts);
+    main_helper::add_program_arguments(&mut opts);
 
     let args: Vec<String> = std::env::args().collect();
 

--- a/src/main_helper.rs
+++ b/src/main_helper.rs
@@ -54,6 +54,11 @@ pub fn add_player_arguments(opts: &mut getopts::Options) {
     opts.optopt("", "device", "Audio device to use. Use '?' to list options", "DEVICE");
 }
 
+pub fn add_program_arguments(opts: &mut getopts::Options) {
+    opts.optopt("", "onstart", "Run PROGRAM when playback is about to begin.", "PROGRAM");
+    opts.optopt("", "onstop", "Run PROGRAM when playback has ended.", "PROGRAM");
+}
+
 pub fn create_session(matches: &getopts::Matches) -> Session {
     info!("librespot {} ({}). Built on {}.",
              version::short_sha(),
@@ -77,10 +82,15 @@ pub fn create_session(matches: &getopts::Matches) -> Session {
         Box::new(DefaultCache::new(PathBuf::from(cache_location)).unwrap()) as Box<Cache + Send + Sync>
     }).unwrap_or_else(|| Box::new(NoCache) as Box<Cache + Send + Sync>);
 
+    let onstart = matches.opt_str("onstart");
+    let onstop = matches.opt_str("onstop");
+
     let config = Config {
         user_agent: version::version_string(),
         device_name: name,
         bitrate: bitrate,
+        onstart: onstart,
+        onstop: onstop,
     };
 
     Session::new(config, cache)

--- a/src/session.rs
+++ b/src/session.rs
@@ -39,6 +39,8 @@ pub struct Config {
     pub user_agent: String,
     pub device_name: String,
     pub bitrate: Bitrate,
+    pub onstart: Option<String>,
+    pub onstop: Option<String>,
 }
 
 pub struct SessionData {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::ops::{Mul, Rem, Shr};
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 use std::time::{UNIX_EPOCH, SystemTime};
 
 mod int128;
@@ -49,6 +50,16 @@ pub fn mkdir_existing(path: &Path) -> io::Result<()> {
             Err(err)
         }
     })
+}
+
+pub fn run_program(program: &String) {
+    info!("Running {}", program);
+    let mut v: Vec<&str> = program.split_whitespace().collect();
+    let status = Command::new(&v.remove(0))
+            .args(&v)
+            .status()
+            .expect("program failed to start");
+    info!("Exit status: {}", status);
 }
 
 pub fn powm(base: &BigUint, exp: &BigUint, modulus: &BigUint) -> BigUint {


### PR DESCRIPTION
The `--onstart` and `--onstop` command line options can be used to run a
program when the audio playback is about to begin or has ended.

Note, that librespot needs executions rights to run the program.
Furthermore, the full path needs to be specified, e.g.
`/usr/bin/logger`. Executable scripts must begin with a shebang, e.g.
`#!/bin/sh`.
