### PR TITLE
stdout-backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ script:
     - cargo build --no-default-features --features "with-syntex facebook"
     - cargo build --no-default-features --features "with-syntex portaudio-backend"
     - cargo build --no-default-features --features "with-syntex pulseaudio-backend"
+    - cargo build --no-default-features --features "with-syntex stdout-backend"
     - cargo build --no-default-features --features "with-syntex alsa-backend"
     - cargo build --no-default-features --features "with-syntex" --target armv7-unknown-linux-gnueabihf
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ nightly           = ["serde_macros"]
 
 with-tremor       = ["tremor"]
 facebook          = ["hyper/ssl", "openssl"]
+stdout-backend    = []
 alsa-backend      = ["alsa"]
 portaudio-backend = ["portaudio"]
 pulseaudio-backend= ["libpulse-sys"]

--- a/src/audio_backend/mod.rs
+++ b/src/audio_backend/mod.rs
@@ -54,6 +54,11 @@ fn mk_sink<S: Sink + Open + 'static>(device: Option<&str>) -> Box<Sink> {
     Box::new(S::open(device))
 }
 
+#[cfg(feature = "stdout-backend")]
+mod stdout;
+#[cfg(feature = "stdout-backend")]
+use self::stdout::StdoutSink;
+
 #[cfg(feature = "alsa-backend")]
 mod alsa;
 #[cfg(feature = "alsa-backend")]
@@ -75,6 +80,8 @@ declare_backends! {
         (&'static str,
          &'static (Fn(Option<&str>) -> Box<Sink> + Sync + Send + 'static))
     ] = &[
+        #[cfg(feature = "stdout-backend")]
+        ("stdout", &mk_sink::<StdoutSink>),
         #[cfg(feature = "alsa-backend")]
         ("alsa", &mk_sink::<AlsaSink>),
         #[cfg(feature = "portaudio-backend")]

--- a/src/audio_backend/stdout.rs
+++ b/src/audio_backend/stdout.rs
@@ -1,0 +1,33 @@
+use super::{Open, Sink};
+use std::io::{self, Write};
+use std::slice;
+use std::mem;
+
+
+pub struct StdoutSink;//Option<PCM>, String);
+
+impl Open for StdoutSink {
+    fn open(_: Option<&str>) -> StdoutSink {
+        StdoutSink
+    }
+}
+
+impl Sink for StdoutSink {
+    fn start(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn stop(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn write(&mut self, data: &[i16]) -> io::Result<()> {
+// http://stackoverflow.com/questions/30838358/writing-vecu16-to-a-file
+        let slice_u8: &[u8] = unsafe { slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * mem::size_of::<i16>()) };
+		try!(io::stdout().write_all(slice_u8));
+		try!(io::stdout().flush());
+
+        Ok(())
+    }
+}
+


### PR DESCRIPTION
New audio backend "stdout" (compile with `--features portaudio-backend`) that simply writes the PCM stream to stdout, so that it can be redirected with a simple pipe.
