### PR TITLE
Add Nil Backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ facebook          = ["hyper/ssl", "openssl"]
 alsa-backend      = ["alsa"]
 portaudio-backend = ["portaudio"]
 pulseaudio-backend= ["libpulse-sys"]
+nil-backend       = []
 default           = ["with-syntex", "portaudio-backend"]
 
 [package.metadata.deb]

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ target/release/librespot [...] --backend portaudio
 
 The following backends are currently available :
 - ALSA
-- PortAudio 
+- PortAudio
 - PulseAudio
+- Nil (a black-hole for music bits)
 
 ## Development
 When developing *librespot*, it is preferable to use Rust nightly, and build it using the following :
@@ -88,4 +89,3 @@ https://gitter.im/sashahilton00/spotify-connect-resources
 
 ## License
 Everything in this repository is licensed under the MIT license.
-

--- a/src/audio_backend/mod.rs
+++ b/src/audio_backend/mod.rs
@@ -69,6 +69,10 @@ mod pulseaudio;
 #[cfg(feature = "pulseaudio-backend")]
 use self::pulseaudio::PulseAudioSink;
 
+#[cfg(feature = "nil-backend")]
+mod nil;
+#[cfg(feature = "nil-backend")]
+use self::nil::NilSink;
 
 declare_backends! {
     pub const BACKENDS : &'static [
@@ -81,5 +85,7 @@ declare_backends! {
         ("portaudio", &mk_sink::<PortAudioSink>),
         #[cfg(feature = "pulseaudio-backend")]
         ("pulseaudio", &mk_sink::<PulseAudioSink>),
+        #[cfg(feature = "nil-backend")]
+        ("nil", &mk_sink::<NilSink>),
     ];
 }

--- a/src/audio_backend/nil.rs
+++ b/src/audio_backend/nil.rs
@@ -1,0 +1,24 @@
+use super::{Open, Sink};
+use std::io;
+
+pub struct NilSink();
+
+impl Open for NilSink {
+    fn open(_device: Option<&str>) -> NilSink {
+        NilSink()
+    }
+}
+
+impl Sink for NilSink {
+    fn start(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn stop(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn write(&mut self, _data: &[i16]) -> io::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adds a Nil backend to librespot. This acts as a (not-so-)musical `/dev/null`; bytes are discarded with a Success indicated. Use case is a service building on top of librespot that does not require the ability to play music, such as one interested only in metadata. 