### PR TITLE
add basic systemd service unit example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,5 +92,6 @@ available in the official library."""
 section = "sound"
 priority = "optional"
 assets = [
-    ["target/release/librespot", "usr/bin/", "755"]
+    ["target/release/librespot", "usr/bin/", "755"],
+    ["assets/librespot.service", "lib/systemd/system/", "644"]
 ]

--- a/assets/librespot.service
+++ b/assets/librespot.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Librespot
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+#User=librespot
+Restart=always
+RestartSec=10
+ExecStart=/usr/bin/librespot -n "%p on %H"
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
adds a simple systemd unit example for Linux so that librespot can be started automatically on boot