### PR TITLE
systemd: don't run as root, drop privileges

### DIFF
--- a/assets/librespot.service
+++ b/assets/librespot.service
@@ -4,7 +4,8 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
-#User=librespot
+User=nobody
+Group=audio
 Restart=always
 RestartSec=10
 ExecStart=/usr/bin/librespot -n "%p on %H"


### PR DESCRIPTION
nobody:audio should exists on most distributions
explicit user would be prefered

sorry, forgot about that