### PR TITLE
Improve for library users

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,11 +32,11 @@ fn main() {
 
     main_helper::setup_logging(&matches);
 
-    let session = main_helper::create_session(&matches);
-    let credentials = main_helper::get_credentials(&session, &matches);
+    let session = main_helper::session_from_matches(&matches);
+    let credentials = main_helper::credentials_from_matches(&session, &matches);
     session.login(credentials).unwrap();
 
-    let player = main_helper::create_player(&session, &matches);
+    let player = main_helper::player_from_matches(&session, &matches);
 
     let spirc = SpircManager::new(session.clone(), player);
     let spirc_signal = spirc.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,11 +32,11 @@ fn main() {
 
     main_helper::setup_logging(&matches);
 
-    let session = main_helper::session_from_matches(&matches);
-    let credentials = main_helper::credentials_from_matches(&session, &matches);
+    let session = main_helper::create_session(&matches);
+    let credentials = main_helper::get_credentials(&session, &matches);
     session.login(credentials).unwrap();
 
-    let player = main_helper::player_from_matches(&session, &matches);
+    let player = main_helper::create_player(&session, &matches);
 
     let spirc = SpircManager::new(session.clone(), player);
     let spirc_signal = spirc.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::thread;
 
 use librespot::spirc::SpircManager;
 use librespot::main_helper;
+use librespot::authentication::get_credentials;
 
 fn usage(program: &str, opts: &getopts::Options) -> String {
     let brief = format!("Usage: {} [options]", program);
@@ -33,7 +34,8 @@ fn main() {
     main_helper::setup_logging(&matches);
 
     let session = main_helper::create_session(&matches);
-    let credentials = main_helper::get_credentials(&session, &matches);
+    let credentials = get_credentials(&session, matches.opt_str("username"),
+                                      matches.opt_str("password"));
     session.login(credentials).unwrap();
 
     let player = main_helper::create_player(&session, &matches);

--- a/src/main_helper.rs
+++ b/src/main_helper.rs
@@ -55,14 +55,26 @@ pub fn add_player_arguments(opts: &mut getopts::Options) {
         .optopt("", "device", "Audio device to use. Use '?' to list options", "DEVICE");
 }
 
-pub fn create_session(matches: &getopts::Matches) -> Session {
+pub fn session_from_matches(matches: &getopts::Matches) -> Session {
+    create_session(matches.opt_str("n").unwrap(),
+                   matches.opt_str("b").as_ref().map(String::as_ref),
+                   matches.opt_str("c").as_ref().map(String::as_ref),
+                   matches.opt_str("onstart"),
+                   matches.opt_str("onstop"))
+}
+
+pub fn create_session(name: String,
+                      bitrate: Option<&str>,
+                      cache: Option<&str>,
+                      onstart: Option<String>,
+                      onstop: Option<String>)
+                      -> Session {
     info!("librespot {} ({}). Built on {}.",
              version::short_sha(),
              version::commit_date(),
              version::short_now());
 
-    let name = matches.opt_str("n").unwrap();
-    let bitrate = match matches.opt_str("b").as_ref().map(String::as_ref) {
+    let bitrate = match bitrate {
         None => Bitrate::Bitrate160, // default value
 
         Some("96") => Bitrate::Bitrate96,
@@ -74,12 +86,9 @@ pub fn create_session(matches: &getopts::Matches) -> Session {
         }
     };
 
-    let cache = matches.opt_str("c").map(|cache_location| {
+    let cache = cache.map(|cache_location| {
         Box::new(DefaultCache::new(PathBuf::from(cache_location)).unwrap()) as Box<Cache + Send + Sync>
     }).unwrap_or_else(|| Box::new(NoCache) as Box<Cache + Send + Sync>);
-
-    let onstart = matches.opt_str("onstart");
-    let onstop = matches.opt_str("onstop");
 
     let config = Config {
         user_agent: version::version_string(),
@@ -92,13 +101,16 @@ pub fn create_session(matches: &getopts::Matches) -> Session {
     Session::new(config, cache)
 }
 
-pub fn get_credentials(session: &Session, matches: &getopts::Matches) -> Credentials {
+pub fn credentials_from_matches(session: &Session,
+                                matches: &getopts::Matches) -> Credentials {
+    get_credentials(session, matches.opt_str("username"), matches.opt_str("password"))
+}
+
+pub fn get_credentials(session: &Session, username: Option<String>,
+                       password: Option<String>) -> Credentials {
     let credentials = session.cache().get_credentials();
 
-    match (matches.opt_str("username"),
-           matches.opt_str("password"),
-           credentials) {
-
+    match (username, password, credentials) {
         (Some(username), Some(password), _)
             => Credentials::with_password(username, password),
 
@@ -122,11 +134,14 @@ pub fn get_credentials(session: &Session, matches: &getopts::Matches) -> Credent
     }
 }
 
-pub fn create_player(session: &Session, matches: &getopts::Matches) -> Player {
-    let backend_name = matches.opt_str("backend");
-    let device_name = matches.opt_str("device");
+pub fn player_from_matches(session: &Session, matches: &getopts::Matches) -> Player {
+    create_player(session, matches.opt_str("backend").as_ref().map(String::as_ref)
+                  , matches.opt_str("device"))
+}
 
-    let make_backend = find_backend(backend_name.as_ref().map(AsRef::as_ref));
+pub fn create_player(session: &Session, backend_name: Option<&str>
+                     , device_name: Option<String>) -> Player {
+    let make_backend = find_backend(backend_name);
 
     Player::new(session.clone(), move || {
         make_backend(device_name.as_ref().map(AsRef::as_ref))

--- a/src/session.rs
+++ b/src/session.rs
@@ -28,7 +28,7 @@ use version;
 
 use stream;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub enum Bitrate {
     Bitrate96,
     Bitrate160,

--- a/src/session.rs
+++ b/src/session.rs
@@ -28,6 +28,7 @@ use version;
 
 use stream;
 
+#[derive(Clone, Copy)]
 pub enum Bitrate {
     Bitrate96,
     Bitrate160,


### PR DESCRIPTION
For Spotifyd, I'm reading configuration from configuration files. In order to not have to reinvent the wheel, I'd like the functions in `main_helper` to be generic enough that I can pass in data from any source. This should be of benefit for anyone using the library.

I also gave `Bitrate` copy semantics, because it bothered me a bit 😃 