### PR TITLE
Improve log strings and never log to stdout.

### DIFF
--- a/src/audio_backend/alsa.rs
+++ b/src/audio_backend/alsa.rs
@@ -6,7 +6,7 @@ pub struct AlsaSink(Option<PCM>, String);
 
 impl Open for AlsaSink {
    fn open(device: Option<&str>) -> AlsaSink {
-        println!("Using alsa sink");
+        info!("Using alsa sink");
 
         let name = device.unwrap_or("default").to_string();
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -180,12 +180,12 @@ fn find_available_alternative<'a>(session: &Session, track: &'a Track) -> Option
 fn load_track(session: &Session, track_id: SpotifyId) -> Option<vorbis::Decoder<Subfile<AudioDecrypt<Box<ReadSeek>>>>> {
     let track = session.metadata::<Track>(track_id).await().unwrap();
 
-    info!("Loading track {:?}", track.name);
+    info!("Loading track \"{}\"", track.name);
 
     let track = match find_available_alternative(session, &track) {
         Some(track) => track,
         None => {
-            warn!("Track {:?} is not available", track.name);
+            warn!("Track \"{}\" is not available", track.name);
             return None;
         }
     };


### PR DESCRIPTION
Remove log message to `stdout`, and stop using debug formatting for nicer looking logs.