### PR TITLE
Allow passing additional arguments to the systemd service

### DIFF
--- a/assets/librespot.conf
+++ b/assets/librespot.conf
@@ -1,0 +1,1 @@
+LIBRESPOT_ARGS=""

--- a/assets/librespot.service
+++ b/assets/librespot.service
@@ -8,7 +8,8 @@ User=nobody
 Group=audio
 Restart=always
 RestartSec=10
-ExecStart=/usr/bin/librespot -n "%p on %H"
+EnvironmentFile=-/etc/conf.d/librespot.conf
+ExecStart=/usr/bin/librespot -n "%p on %H" $LIBRESPOT_ARGS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This commit allows passing additional arguments defined
in /etc/conf.d/librespot.conf (if it exists) to the librespot call.