### PR TITLE
Add websockets server to librespot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ dependencies = [
  "ctrlc 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "eventual 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "extprim 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "json_macros 0.3.1 (git+https://github.com/plietar/json_macros)",
@@ -36,6 +37,7 @@ dependencies = [
  "url 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "vergen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vorbis 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -117,6 +119,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bytes"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +179,16 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syncbox 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "extprim"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -362,6 +379,22 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mio"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -725,6 +758,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "shannon"
 version = "0.1.1"
 source = "git+https://github.com/plietar/rust-shannon#613aa1e752b3247a30d2c866bb45f0170e9df8d6"
@@ -742,6 +780,11 @@ dependencies = [
  "gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "slab"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "slab"
@@ -1132,6 +1175,19 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ws"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "httparse 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1209,7 @@ dependencies = [
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
+"checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum ctrlc 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77f98bb69e3fefadcc5ca80a1368a55251f70295168203e01165bcaecb270891"
@@ -1160,6 +1217,7 @@ dependencies = [
 "checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum eventual 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b9bda6d089b434ca50f3d6feb5fca421309b8bac97b8be9af51cff879fa3f54b"
+"checksum extprim 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e16638eb41eb5d4cd055b5e2bea4006a9001ecb0467ca81314f8be1d611522b8"
 "checksum futures 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "177a82a61dd7e528022ce97f24e54b499dd2fee4d4646a0f283c5fb500dbfe20"
 "checksum gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)" = "3689e1982a563af74960ae3a4758aa632bb8fd984cfc3cc3b60ee6109477ab6e"
 "checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
@@ -1183,6 +1241,7 @@ dependencies = [
 "checksum mdns 0.2.0 (git+https://github.com/plietar/rust-mdns)" = "<none>"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5c93a4bd787ddc6e7833c519b73a50883deb5863d76d9b71eb8216fb7f94e66"
+"checksum mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a637d1ca14eacae06296a008fa7ad955347e34efcb5891cfd8ba05491a37907e"
 "checksum mio 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5b493dc9fd96bd2077f2117f178172b0765db4dfda3ea4d8000401e6d65d3e80"
 "checksum miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3e690c5df6b2f60acd45d56378981e827ff8295562fc8d34f573deb267a59cd1"
 "checksum multimap 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e85cb6b79f81830421066428f1f8f47032d77843dc569040a7d056b80f95d5d4"
@@ -1223,8 +1282,10 @@ dependencies = [
 "checksum serde_codegen_internals 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1b0115c5c602e81c61b787fb0f0fa76a614f8dbe9100b2b59b7d590155672c80"
 "checksum serde_json 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7d3c184d35801fb8b32b46a7d58d57dbcc150b0eb2b46a1eb79645e8ecfd5b"
 "checksum serde_macros 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c3cf1c01933271e1e72bb788e0499d1bca8af2c09efcc3ddc0b04ff22d080b83"
+"checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum shannon 0.1.1 (git+https://github.com/plietar/rust-shannon)" = "<none>"
 "checksum shannon-sys 0.1.0 (git+https://github.com/plietar/rust-shannon)" = "<none>"
+"checksum slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d807fd58c4181bbabed77cb3b891ba9748241a552bcc5be698faaebefc54f46e"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum syncbox 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "05bc2b72659ac27a2d0e7c4166c8596578197c4c41f767deab12c81f523b85c7"
@@ -1267,4 +1328,5 @@ dependencies = [
 "checksum vorbisfile-sys 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4f4306d7e1ac4699b55e20de9483750b90c250913188efd7484db6bfbe9042d1"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum ws 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7c47e9ca2f5c47d27f731b1bb9bb50cc05f9886bb84fbd52afa0ff97f4f61b06"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ byteorder       = "1.0"
 ctrlc           = { version = "2.0", features = ["termination"] }
 env_logger      = "0.3.2"
 eventual        = "0.1.6"
+extprim         = "~1.1.0" 
 getopts         = "0.2.14"
 hyper           = { version = "0.9.1", default-features = false }
 lazy_static     = "0.2.0"
@@ -44,6 +45,7 @@ serde_macros    = { version = "0.8", optional = true }
 shannon         = { git = "https://github.com/plietar/rust-shannon" }
 tempfile        = "2.1"
 url             = "0.5.0"
+ws              = "0.5.3"
 
 vorbis          = "0.1.0"
 tremor          = { git = "https://github.com/plietar/rust-tremor", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate bit_set;
 extern crate byteorder;
 extern crate crypto;
 extern crate eventual;
+extern crate extprim;
 extern crate getopts;
 extern crate hyper;
 extern crate linear_map;
@@ -30,6 +31,7 @@ extern crate serde_json;
 extern crate shannon;
 extern crate tempfile;
 extern crate url;
+extern crate ws;
 
 extern crate librespot_protocol as protocol;
 
@@ -60,6 +62,7 @@ pub mod player;
 pub mod stream;
 pub mod util;
 pub mod version;
+pub mod websockets;
 
 #[cfg(feature = "with-syntex")] include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 #[cfg(not(feature = "with-syntex"))] include!("lib.in.rs");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate getopts;
 extern crate librespot;
 extern crate ctrlc;
 extern crate env_logger;
+extern crate ws;
 
 use env_logger::LogBuilder;
 use std::io::{stderr, Write};
@@ -19,6 +20,7 @@ use librespot::cache::{Cache, DefaultCache, NoCache};
 use librespot::player::Player;
 use librespot::session::{Bitrate, Config, Session};
 use librespot::version;
+use librespot::websockets;
 
 fn usage(program: &str, opts: &getopts::Options) -> String {
     let brief = format!("Usage: {} [options]", program);
@@ -135,6 +137,7 @@ fn main() {
     let spirc = SpircManager::new(session.clone(), player);
     let spirc_signal = spirc.clone();
     thread::spawn(move || spirc.run());
+    thread::spawn(move || websockets::setup_websockets());
 
     ctrlc::set_handler(move || {
         spirc_signal.send_goodbye();

--- a/src/util/spotify_id.rs
+++ b/src/util/spotify_id.rs
@@ -1,5 +1,5 @@
 use std;
-use util::u128;
+use extprim::u128::u128;
 use byteorder::{BigEndian, ByteOrder};
 use std::ascii::AsciiExt;
 
@@ -20,9 +20,9 @@ impl SpotifyId {
 
         let mut n: u128 = u128::zero();
         for c in data {
-            let d = BASE16_DIGITS.iter().position(|e| e == c).unwrap() as u8;
-            n = n * u128::from(16);
-            n = n + u128::from(d);
+            let d = BASE16_DIGITS.iter().position(|e| e == c).unwrap() as u64; 
+            n = n * u128::new(16); 
+            n = n + u128::new(d);
         }
 
         SpotifyId(n)
@@ -34,9 +34,9 @@ impl SpotifyId {
 
         let mut n: u128 = u128::zero();
         for c in data {
-            let d = BASE62_DIGITS.iter().position(|e| e == c).unwrap() as u8;
-            n = n * u128::from(62);
-            n = n + u128::from(d);
+            let d = BASE62_DIGITS.iter().position(|e| e == c).unwrap() as u64; 
+            n = n * u128::new(62); 
+            n = n + u128::new(d);
         }
 
         SpotifyId(n)
@@ -53,14 +53,23 @@ impl SpotifyId {
 
     pub fn to_base16(&self) -> String {
         let &SpotifyId(ref n) = self;
-        let (high, low) = n.parts();
 
         let mut data = [0u8; 32];
-        for i in 0..16 {
-            data[31 - i] = BASE16_DIGITS[(low.wrapping_shr(4 * i as u32) & 0xF) as usize];
+        for i in 0..32 { 
+            data[31 - i] = BASE16_DIGITS[(n.wrapping_shr(4 * i as u32).low64() & 0xF) as usize]; 
         }
-        for i in 0..16 {
-            data[15 - i] = BASE16_DIGITS[(high.wrapping_shr(4 * i as u32) & 0xF) as usize];
+
+        std::str::from_utf8(&data).unwrap().to_owned()
+    }
+    
+    pub fn to_base62(&self) -> String {
+        let &SpotifyId(mut n) = self;
+
+        let mut data = [0u8; 22];
+        let sixty_two = u128::new(62);
+        for i in 0..22 {
+            data[21-i] = BASE62_DIGITS[(n % sixty_two).low64() as usize];
+            n /= sixty_two;
         }
 
         std::str::from_utf8(&data).unwrap().to_owned()
@@ -68,12 +77,11 @@ impl SpotifyId {
 
     pub fn to_raw(&self) -> [u8; 16] {
         let &SpotifyId(ref n) = self;
-        let (high, low) = n.parts();
 
         let mut data = [0u8; 16];
 
-        BigEndian::write_u64(&mut data[0..8], high);
-        BigEndian::write_u64(&mut data[8..16], low);
+        BigEndian::write_u64(&mut data[0..8], n.high64()); 
+        BigEndian::write_u64(&mut data[8..16], n.low64());
 
         data
     }

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -44,13 +44,6 @@ impl Handler for Server {
     }
 }
 
-impl Server {
-    pub fn broadcast_message(&mut self, msg: Message) -> Result<()> {
-        //self is a mutable reference to the Server struct containing the out variable from below.
-        self.out.broadcast(msg)
-    }
-}
-
 pub fn broadcast_message(msg: Message) -> Result<()> {
     //self is a mutable reference to the Server struct containing the out variable from below.
     connect("ws://127.0.0.1:3012", |out| {

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -1,0 +1,72 @@
+use ws::{connect, listen, Handler, Sender, Handshake, Result, Message, CloseCode, Error};
+use version;
+
+pub struct Server {
+    pub out: Sender,
+}
+
+pub struct Client {
+    pub out: Sender,
+}
+
+impl Handler for Server {
+
+    fn on_message(&mut self, msg: Message) -> Result<()> {
+        // TODO: Allow client to send WS commands to spirc. Currently just broadcast the message back.
+        //self.broadcast_message(Message::from("Testing"));
+        self.out.broadcast(msg)
+        //self.out.send(msg)
+    }
+    
+    fn on_open(&mut self, _: Handshake) -> Result<()> {
+        // We have a new connection, say hello
+        self.out.send(format!("WebSockets Server for librespot {} ({}). Built on {}.",
+             version::short_sha(),
+             version::commit_date(),
+             version::short_now()))
+    }
+
+    fn on_close(&mut self, code: CloseCode, reason: &str) {
+        // The WebSocket protocol allows for a utf8 reason for the closing state after the
+        // close code. WS-RS will attempt to interpret this data as a utf8 description of the
+        // reason for closing the connection. I many cases, `reason` will be an empty string.
+        // So, you may not normally want to display `reason` to the user,
+        // but let's assume that we know that `reason` is human-readable.
+        match code {
+            CloseCode::Normal => println!("Client closed the connection."),
+            CloseCode::Away   => println!("Client dropped the connection."),
+            _ => println!("Error connecting to client: {}", reason),
+        }
+    }
+    
+    fn on_error(&mut self, err: Error) {
+        println!("The server encountered an error: {:?}", err);
+    }
+}
+
+impl Server {
+    pub fn broadcast_message(&mut self, msg: Message) -> Result<()> {
+        //self is a mutable reference to the Server struct containing the out variable from below.
+        self.out.broadcast(msg)
+    }
+}
+
+pub fn broadcast_message(msg: Message) -> Result<()> {
+    //self is a mutable reference to the Server struct containing the out variable from below.
+    connect("ws://127.0.0.1:3012", |out| {
+        out.broadcast(msg.clone()).unwrap();
+
+        move |msg| {
+            out.close(CloseCode::Normal)
+        }
+    })
+ }
+
+
+pub fn setup_websockets() {
+    listen("127.0.0.1:3012", |out| {
+        Server {
+            out: out,
+        }
+    }).unwrap();
+}


### PR DESCRIPTION
Adds web socket server. Badly coded, intended as PoC. Aka. Can't Recommend A Pull (request). Also updates spotify_id.rs with new methods.

It would be good to have something like a websockets server that makes it easy for users who do not have a good grasp of rust (me)/want to integrate with librespot in a relatively easy/quick manner for whatever project they are working on. Hence this PR includes some barebones functionality that allows one to get the current activity of librespot via a websockets server running on  port 3012. It would be good if someone who has a clue what they are doing could look at and rewrite it so that librespot is not hosting a websocket server in one part of the application, then starting a client in another part just to send out the messages. From there it would be possible to add things such as client side queries, proper metadata, play queues, etc.

Like I said, this code is rubbish, and should be left in a separate branch to master. As it currently stands there are a number of issues not limited to:
1. Client has to wait for next song to load before being able to see what song is playing
2. Client cannot query librespot, only listen to server events.
3. There is no control over what the websocket server sends out in any way. It would be perfectly possible for someone on your network to send JSON messages to the server to make all connected clients think Rick Astley was the only artist playing, etc. You get the idea.
4. Rubbish code, both in terms of design and implementation. Still, beggars can't be choosers.

S.