### PR TITLE
Add support for ALSA softvol plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "librespot"
 version = "0.1.0"
 dependencies = [
- "alsa 0.0.1 (git+https://github.com/plietar/rust-alsa)",
+ "alsa 0.1.3 (git+https://github.com/diwic/alsa-rs)",
  "base64 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -50,10 +50,21 @@ dependencies = [
 
 [[package]]
 name = "alsa"
-version = "0.0.1"
-source = "git+https://github.com/plietar/rust-alsa#8c63543fa0ccd971cf15f5675293d19febd6f79e"
+version = "0.1.3"
+source = "git+https://github.com/diwic/alsa-rs#2dc3888fd55c48e66abb6f1a24f5f360ca945648"
+dependencies = [
+ "alsa-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -93,6 +104,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -932,13 +948,15 @@ dependencies = [
 
 [metadata]
 "checksum aho-corasick 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0638fd549427caa90c499814196d1b9e3725eb4d15d7339d6de073a680ed0ca2"
-"checksum alsa 0.0.1 (git+https://github.com/plietar/rust-alsa)" = "<none>"
+"checksum alsa 0.1.3 (git+https://github.com/diwic/alsa-rs)" = "<none>"
+"checksum alsa-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2c3f84e271f1613d7d7cbf6608beaed341c3f3d7e57045a6fc1a7d112380613c"
 "checksum aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfdf7355d9db158df68f976ed030ab0f6578af811f5a7bb6dcf221ec24e0e0"
 "checksum base64 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "065a0ce220ab84d0b6d5ae3e7bb77232209519c366f51f946fe28c19e84989d0"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
 "checksum bit-vec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5b97c2c8e8bbb4251754f559df8af22fb264853c7d009084a576cdf12565089d"
 "checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
+"checksum bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e1ab483fc81a8143faa7203c4a3c02888ebd1a782e37e41fa34753ba9a162"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ url             = "1.3"
 vorbis          = "0.1.0"
 tremor          = { git = "https://github.com/plietar/rust-tremor", optional = true }
 
-alsa            = { git = "https://github.com/plietar/rust-alsa", optional = true }
+alsa            = { git = "https://github.com/diwic/alsa-rs", optional = true }
 portaudio       = { git = "https://github.com/mvdnes/portaudio-rs", optional = true }
 libpulse-sys    = { git = "https://github.com/astro/libpulse-sys", optional = true }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ struct Setup {
     backend: fn(Option<String>) -> Box<Sink>,
     device: Option<String>,
 
-    mixer: fn() -> Box<Mixer>,
+    mixer: fn(Option<String>) -> Box<Mixer>,
 
     cache: Option<Cache>,
     config: Config,
@@ -169,7 +169,7 @@ struct Main {
     config: Config,
     backend: fn(Option<String>) -> Box<Sink>,
     device: Option<String>,
-    mixer: fn() -> Box<Mixer>,
+    mixer: fn(Option<String>) -> Box<Mixer>,
     handle: Handle,
 
     discovery: Option<DiscoveryStream>,
@@ -188,7 +188,7 @@ impl Main {
            cache: Option<Cache>,
            backend: fn(Option<String>) -> Box<Sink>,
            device: Option<String>,
-           mixer: fn() -> Box<Mixer>) -> Main
+           mixer: fn(Option<String>) -> Box<Mixer>) -> Main
     {
         Main {
             handle: handle.clone(),
@@ -248,10 +248,11 @@ impl Future for Main {
             if let Async::Ready(session) = self.connect.poll().unwrap() {
                 self.connect = Box::new(futures::future::empty());
                 let device = self.device.clone();
-                let mixer = (self.mixer)();
+                let mixer = (self.mixer)(device);
 
                 let audio_filter = mixer.get_audio_filter();
                 let backend = self.backend;
+                let device = self.device.clone();
                 let player = Player::new(session.clone(), audio_filter, move || {
                     (backend)(device)
                 });

--- a/src/mixer/alsasoftvol.rs
+++ b/src/mixer/alsasoftvol.rs
@@ -1,0 +1,45 @@
+use super::Mixer;
+use super::AudioFilter;
+
+use alsa;
+
+#[derive(Clone)]
+pub struct AlsaSoftVol {
+    name: String
+}
+
+impl Mixer for AlsaSoftVol {
+    fn open(device: Option<String>) -> AlsaSoftVol {
+        let name = device.unwrap_or("default".to_string());
+        AlsaSoftVol {
+            name: name
+        }
+    }
+    fn start(&self) {
+    }
+    fn stop(&self) {
+    }
+    fn volume(&self) -> u16 {
+        let mixer = alsa::mixer::Mixer::new(&self.name, false).unwrap();
+        let selem_id = alsa::mixer::SelemId::new("Master", 0);
+        let selem = mixer.find_selem(&selem_id).unwrap();
+
+        let volume: i64 = selem.get_playback_volume(alsa::mixer::SelemChannelId::FrontLeft).unwrap();
+
+        volume as u16 * 256
+    }
+
+    fn set_volume(&self, volume: u16) {
+        let volume: i64 = volume as i64 / 256;
+
+        let mixer = alsa::mixer::Mixer::new(&self.name, false).unwrap();
+        let selem_id = alsa::mixer::SelemId::new("Master", 0);
+        let selem = mixer.find_selem(&selem_id).unwrap();
+
+        selem.set_playback_volume(alsa::mixer::SelemChannelId::FrontLeft, volume).unwrap();
+        selem.set_playback_volume(alsa::mixer::SelemChannelId::FrontRight, volume).unwrap();
+    }
+    fn get_audio_filter(&self) -> Option<Box<AudioFilter + Send>> {
+        None
+    }
+}

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -1,5 +1,5 @@
 pub trait Mixer : Send {
-    fn open() -> Self where Self: Sized;
+    fn open(Option<String>) -> Self where Self: Sized;
     fn start(&self);
     fn stop(&self);
     fn set_volume(&self, volume: u16);
@@ -16,11 +16,11 @@ pub trait AudioFilter {
 pub mod softmixer;
 use self::softmixer::SoftMixer;
 
-fn mk_sink<M: Mixer + 'static>() -> Box<Mixer> {
-    Box::new(M::open())
+fn mk_sink<M: Mixer + 'static>(device: Option<String>) -> Box<Mixer> {
+    Box::new(M::open(device))
 }
 
-pub fn find<T: AsRef<str>>(name: Option<T>) -> Option<fn() -> Box<Mixer>> {
+pub fn find<T: AsRef<str>>(name: Option<T>) -> Option<fn(Option<String>) -> Box<Mixer>> {
     match name.as_ref().map(AsRef::as_ref) {
         None | Some("softvol") => Some(mk_sink::<SoftMixer>),
         _ => None,

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -16,6 +16,11 @@ pub trait AudioFilter {
 pub mod softmixer;
 use self::softmixer::SoftMixer;
 
+#[cfg(feature = "alsa-backend")]
+pub mod alsasoftvol;
+#[cfg(feature = "alsa-backend")]
+use self::alsasoftvol::AlsaSoftVol;
+
 fn mk_sink<M: Mixer + 'static>(device: Option<String>) -> Box<Mixer> {
     Box::new(M::open(device))
 }
@@ -23,6 +28,8 @@ fn mk_sink<M: Mixer + 'static>(device: Option<String>) -> Box<Mixer> {
 pub fn find<T: AsRef<str>>(name: Option<T>) -> Option<fn(Option<String>) -> Box<Mixer>> {
     match name.as_ref().map(AsRef::as_ref) {
         None | Some("softvol") => Some(mk_sink::<SoftMixer>),
+        #[cfg(feature = "alsa-backend")]
+        Some("alsasoftvol") => Some(mk_sink::<AlsaSoftVol>),
         _ => None,
     }
 }

--- a/src/mixer/softmixer.rs
+++ b/src/mixer/softmixer.rs
@@ -10,7 +10,7 @@ pub struct SoftMixer {
 }
 
 impl Mixer for SoftMixer {
-    fn open() -> SoftMixer {
+    fn open(_: Option<String>) -> SoftMixer {
         SoftMixer {
             volume: Arc::new(AtomicUsize::new(0xFFFF))
         }

--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -134,9 +134,8 @@ impl Spirc {
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded();
 
-        let volume = 0xFFFF;
+        let volume = mixer.volume();
         let device = initial_device_state(name, volume);
-        mixer.set_volume(volume);
 
         let mut task = SpircTask {
             player: player,


### PR DESCRIPTION
Add support for the [ALSA softvol plugin](http://alsa.opensrc.org/Softvol) as a mixer. The ALSA softvol plugin allows librespot to [control the master volume](http://alsa.opensrc.org/How_to_use_softvol_to_control_the_master_volume).

Therefore, switch to the alsa crate from diwic, as this crate already implements the mixer interface, and port the alsa backend to this crate.

The ALSA softvol plugin needs to audio device name. Therefoe, enhance the mixer interface by passing the device name to the mixer instance. The device name is ignored by the softmixer.

Finally, get the initial volume setting from the mixer. This way, the spotify player uses the last volume instead of setting it always to 100%.

