### PR TITLE
Add initial support for ALSA mixer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "librespot"
 version = "0.1.0"
 dependencies = [
- "alsa 0.0.1 (git+https://github.com/plietar/rust-alsa)",
+ "alsa 0.1.5 (git+https://github.com/diwic/alsa-rs)",
  "base64 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -50,10 +50,21 @@ dependencies = [
 
 [[package]]
 name = "alsa"
-version = "0.0.1"
-source = "git+https://github.com/plietar/rust-alsa#8c63543fa0ccd971cf15f5675293d19febd6f79e"
+version = "0.1.5"
+source = "git+https://github.com/diwic/alsa-rs#b7de845a16072690dd106978377e9df3321d3927"
+dependencies = [
+ "alsa-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -934,7 +945,8 @@ dependencies = [
 
 [metadata]
 "checksum aho-corasick 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0638fd549427caa90c499814196d1b9e3725eb4d15d7339d6de073a680ed0ca2"
-"checksum alsa 0.0.1 (git+https://github.com/plietar/rust-alsa)" = "<none>"
+"checksum alsa 0.1.5 (git+https://github.com/diwic/alsa-rs)" = "<none>"
+"checksum alsa-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9013f855a808ab924a4c08b5c1ec9bd6b04fdb2295b4d570fb723e0ed2802a4f"
 "checksum aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfdf7355d9db158df68f976ed030ab0f6578af811f5a7bb6dcf221ec24e0e0"
 "checksum base64 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "065a0ce220ab84d0b6d5ae3e7bb77232209519c366f51f946fe28c19e84989d0"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ url             = "1.3"
 vorbis          = "0.1.0"
 tremor          = { git = "https://github.com/plietar/rust-tremor", optional = true }
 
-alsa            = { git = "https://github.com/plietar/rust-alsa", optional = true }
+alsa            = { git = "https://github.com/diwic/alsa-rs", optional = true }
 portaudio       = { git = "https://github.com/mvdnes/portaudio-rs", optional = true }
 libpulse-sys    = { git = "https://github.com/astro/libpulse-sys", optional = true }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ struct Setup {
     backend: fn(Option<String>) -> Box<Sink>,
     device: Option<String>,
 
-    mixer: fn() -> Box<Mixer>,
+    mixer: fn(Option<String>) -> Box<Mixer>,
 
     cache: Option<Cache>,
     config: Config,
@@ -169,7 +169,7 @@ struct Main {
     config: Config,
     backend: fn(Option<String>) -> Box<Sink>,
     device: Option<String>,
-    mixer: fn() -> Box<Mixer>,
+    mixer: fn(Option<String>) -> Box<Mixer>,
     handle: Handle,
 
     discovery: Option<DiscoveryStream>,
@@ -188,7 +188,7 @@ impl Main {
            cache: Option<Cache>,
            backend: fn(Option<String>) -> Box<Sink>,
            device: Option<String>,
-           mixer: fn() -> Box<Mixer>) -> Main
+           mixer: fn(Option<String>) -> Box<Mixer>) -> Main
     {
         Main {
             handle: handle.clone(),
@@ -248,10 +248,11 @@ impl Future for Main {
             if let Async::Ready(session) = self.connect.poll().unwrap() {
                 self.connect = Box::new(futures::future::empty());
                 let device = self.device.clone();
-                let mixer = (self.mixer)();
+                let mixer = (self.mixer)(device);
 
                 let audio_filter = mixer.get_audio_filter();
                 let backend = self.backend;
+                let device = self.device.clone();
                 let player = Player::new(session.clone(), audio_filter, move || {
                     (backend)(device)
                 });

--- a/src/mixer/alsamixer.rs
+++ b/src/mixer/alsamixer.rs
@@ -1,0 +1,62 @@
+use super::Mixer;
+use super::AudioFilter;
+
+use alsa;
+
+#[derive(Clone)]
+pub struct AlsaMixer {
+    name: String
+}
+
+impl Mixer for AlsaMixer {
+    fn open(device: Option<String>) -> AlsaMixer {
+        let name = device.unwrap_or("default".to_string());
+        AlsaMixer {
+            name: name
+        }
+    }
+
+    fn start(&self) {
+    }
+
+    fn stop(&self) {
+    }
+
+    fn volume(&self) -> u16 {
+        let mixer = alsa::mixer::Mixer::new(&self.name, false).unwrap();
+        let selem_id = alsa::mixer::SelemId::new("Master", 0);
+        let selem = mixer.find_selem(&selem_id).unwrap();
+        let (min, max) = selem.get_playback_volume_range();
+        let volume: i64 = selem.get_playback_volume(alsa::mixer::SelemChannelId::FrontLeft).unwrap();
+
+        // Spotify uses a volume range from 0 to 65535, but the ALSA mixers resolution might
+        // differ, e.g. most ALSA mixers uses a resolution of 256. Therefore, we have to calculate
+        // the multiplier to use, to get the corresponding Spotify volume value from the ALSA
+        // mixers volume.
+        let resolution = max - min + 1;
+        let multiplier: u16 = (((0xFFFF + 1) / resolution) - 1) as u16;
+
+        volume as u16 * multiplier
+    }
+
+    fn set_volume(&self, volume: u16) {
+        let mixer = alsa::mixer::Mixer::new(&self.name, false).unwrap();
+        let selem_id = alsa::mixer::SelemId::new("Master", 0);
+        let selem = mixer.find_selem(&selem_id).unwrap();
+        let (min, max) = selem.get_playback_volume_range();
+
+        // Spotify uses a volume range from 0 to 65535, but the ALSA mixers resolution might
+        // differ, e.g. most ALSA mixers uses a resolution of 256. Therefore, we have to calculate
+        // the factor to use, to get the corresponding ALSA mixers volume value from the Spotify
+        // volume.
+        let resolution = max - min + 1;
+        let factor: u16 = (((0xFFFF + 1) / resolution) - 1) as u16;
+        let volume: i64 = (volume / factor) as i64;
+
+        selem.set_playback_volume_all(volume).unwrap();
+    }
+
+    fn get_audio_filter(&self) -> Option<Box<AudioFilter + Send>> {
+        None
+    }
+}

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -16,6 +16,11 @@ pub trait AudioFilter {
 pub mod softmixer;
 use self::softmixer::SoftMixer;
 
+#[cfg(feature = "alsa-backend")]
+pub mod alsamixer;
+#[cfg(feature = "alsa-backend")]
+use self::alsamixer::AlsaMixer;
+
 fn mk_sink<M: Mixer + 'static>(device: Option<String>) -> Box<Mixer> {
     Box::new(M::open(device))
 }
@@ -23,6 +28,8 @@ fn mk_sink<M: Mixer + 'static>(device: Option<String>) -> Box<Mixer> {
 pub fn find<T: AsRef<str>>(name: Option<T>) -> Option<fn(Option<String>) -> Box<Mixer>> {
     match name.as_ref().map(AsRef::as_ref) {
         None | Some("softvol") => Some(mk_sink::<SoftMixer>),
+        #[cfg(feature = "alsa-backend")]
+        Some("alsa") => Some(mk_sink::<AlsaMixer>),
         _ => None,
     }
 }

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -1,5 +1,5 @@
 pub trait Mixer : Send {
-    fn open() -> Self where Self: Sized;
+    fn open(Option<String>) -> Self where Self: Sized;
     fn start(&self);
     fn stop(&self);
     fn set_volume(&self, volume: u16);
@@ -16,11 +16,11 @@ pub trait AudioFilter {
 pub mod softmixer;
 use self::softmixer::SoftMixer;
 
-fn mk_sink<M: Mixer + 'static>() -> Box<Mixer> {
-    Box::new(M::open())
+fn mk_sink<M: Mixer + 'static>(device: Option<String>) -> Box<Mixer> {
+    Box::new(M::open(device))
 }
 
-pub fn find<T: AsRef<str>>(name: Option<T>) -> Option<fn() -> Box<Mixer>> {
+pub fn find<T: AsRef<str>>(name: Option<T>) -> Option<fn(Option<String>) -> Box<Mixer>> {
     match name.as_ref().map(AsRef::as_ref) {
         None | Some("softvol") => Some(mk_sink::<SoftMixer>),
         _ => None,

--- a/src/mixer/softmixer.rs
+++ b/src/mixer/softmixer.rs
@@ -10,7 +10,7 @@ pub struct SoftMixer {
 }
 
 impl Mixer for SoftMixer {
-    fn open() -> SoftMixer {
+    fn open(_: Option<String>) -> SoftMixer {
         SoftMixer {
             volume: Arc::new(AtomicUsize::new(0xFFFF))
         }

--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -134,9 +134,8 @@ impl Spirc {
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded();
 
-        let volume = 0xFFFF;
+        let volume = mixer.volume();
         let device = initial_device_state(name, volume);
-        mixer.set_volume(volume);
 
         let mut task = SpircTask {
             player: player,


### PR DESCRIPTION
The ALSA mixer module implements a simple linear volume control. Note, that a linear volume control is not ideal for human audio experience as our ears respond to sound on an exponential curve.

The mixer also works fine with the ALSA softvol plugin which offers an logarithmic attenuation curve.

**TODO**: Use logarithmic curve for hardware mixers.