### PR TITLE
Fixed volume

### DIFF
--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -364,6 +364,7 @@ impl SpircTask {
                 if !self.fixed_volume {
                     self.mixer.set_volume(frame.get_volume() as u16);
                 }
+                debug!("volume {}", volume);
                 self.notify(None);
 
             }

--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -18,6 +18,7 @@ use protocol::spirc::{PlayStatus, State, MessageType, Frame, DeviceState};
 pub struct SpircTask {
     player: Player,
     mixer: Box<Mixer>,
+    fixed_volume: bool,
 
     sequence: SeqGenerator<u32>,
 
@@ -111,7 +112,7 @@ fn initial_device_state(name: String, volume: u16) -> DeviceState {
 }
 
 impl Spirc {
-    pub fn new(session: Session, player: Player, mixer: Box<Mixer>)
+    pub fn new(session: Session, player: Player, mixer: Box<Mixer>, fixed_volume: bool)
         -> (Spirc, SpircTask)
     {
         debug!("new Spirc[{}]", session.session_id());
@@ -141,6 +142,7 @@ impl Spirc {
         let mut task = SpircTask {
             player: player,
             mixer: mixer,
+            fixed_volume: fixed_volume,
 
             sequence: SeqGenerator::new(1),
 
@@ -359,8 +361,11 @@ impl SpircTask {
             MessageType::kMessageTypeVolume => {
                 let volume = frame.get_volume();
                 self.device.set_volume(volume);
-                self.mixer.set_volume(frame.get_volume() as u16);
+                if !self.fixed_volume {
+                    self.mixer.set_volume(frame.get_volume() as u16);
+                }
                 self.notify(None);
+
             }
 
             MessageType::kMessageTypeNotify => {


### PR DESCRIPTION
Add a --fixed-volume setting that keeps volume at 100%. The volume used in the spotify connect communication is logged.

I am running librespot on a raspberry pi connected to an external amplifier with an API. I want the raspberry pi to always output sound at full volume and then I will adjust the volume on the external amplifier based on the logged volume from librespot.