### PR TITLE
Add mixer fixedvol

### DIFF
--- a/src/mixer/fixedmixer.rs
+++ b/src/mixer/fixedmixer.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::Mixer;
+
+#[derive(Clone)]
+pub struct FixedMixer {
+  volume: Arc<AtomicUsize>
+}
+
+impl Mixer for FixedMixer {
+    fn open() -> FixedMixer {
+        FixedMixer {
+            volume: Arc::new(AtomicUsize::new(0xFFFF))
+        }
+    }
+    fn start(&self) {
+    }
+    fn stop(&self) {
+    }
+    fn volume(&self) -> u16 {
+        self.volume.load(Ordering::Relaxed) as u16
+    }
+    fn set_volume(&self, volume: u16) {
+        self.volume.store(volume as usize, Ordering::Relaxed);
+        debug!("volume {}", volume)
+    }
+}

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -16,6 +16,9 @@ pub trait AudioFilter {
 pub mod softmixer;
 use self::softmixer::SoftMixer;
 
+pub mod fixedmixer;
+use self::fixedmixer::FixedMixer;
+
 fn mk_sink<M: Mixer + 'static>() -> Box<Mixer> {
     Box::new(M::open())
 }
@@ -23,6 +26,7 @@ fn mk_sink<M: Mixer + 'static>() -> Box<Mixer> {
 pub fn find<T: AsRef<str>>(name: Option<T>) -> Option<fn() -> Box<Mixer>> {
     match name.as_ref().map(AsRef::as_ref) {
         None | Some("softvol") => Some(mk_sink::<SoftMixer>),
+        Some("fixedvol") => Some(mk_sink::<FixedMixer>),
         _ => None,
     }
 }


### PR DESCRIPTION
Add a new mixer that always outputs sound at 100% volume. To print the current volume that spotify requests, set RUST_LOG=librespot::mixer::fixedmixer=debug

This PR can be applied instead of PR #161 .