### PR TITLE
use rustup.rs for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
     - mkdir -p ~/.cargo
     - echo '[target.armv7-unknown-linux-gnueabihf]' > ~/.cargo/config
     - echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config
-    - sh ~/rust-installer/rustup.sh --prefix=$(rustc --print sysroot) -y --disable-sudo --add-target=armv7-unknown-linux-gnueabihf
+    - rustup target add armv7-unknown-linux-gnueabihf
 
 script:
     - cargo build --no-default-features


### PR DESCRIPTION
Travis switched to installing Rust with rustup.rs: https://github.com/travis-ci/travis-build/commit/8c341da64feaa069b94e406e857459597b27abc3
Cross compilation previously relied on location of rustup.sh, but the new Rust-based `rustup` is now in path.