### PR TITLE
discovery: allow setting port explicitly

### DIFF
--- a/src/authentication/discovery.rs
+++ b/src/authentication/discovery.rs
@@ -13,6 +13,7 @@ use rand;
 use std::collections::BTreeMap;
 use std::io;
 use std::sync::Arc;
+use std::net::{SocketAddr,IpAddr,Ipv4Addr};
 use tokio_core::net::TcpListener;
 use tokio_core::reactor::Handle;
 use url;
@@ -206,12 +207,13 @@ pub struct DiscoveryStream {
     task: Box<Future<Item=(), Error=io::Error>>,
 }
 
-pub fn discovery(handle: &Handle, device_name: String, device_id: String)
+pub fn discovery(handle: &Handle, device_name: String, device_id: String, discovery_port: Option<u16>)
     -> io::Result<DiscoveryStream>
 {
     let (discovery, creds_rx) = Discovery::new(device_name.clone(), device_id);
+    let bind_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), discovery_port.unwrap_or(0));
 
-    let listener = TcpListener::bind(&"0.0.0.0:0".parse().unwrap(), handle)?;
+    let listener = TcpListener::bind(&bind_addr, handle)?;
     let addr = listener.local_addr()?;
 
     let http = Http::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,7 @@ fn setup(args: &[String]) -> Setup {
         .optflag("v", "verbose", "Enable verbose output")
         .optopt("u", "username", "Username to sign in with", "USERNAME")
         .optopt("p", "password", "Password", "PASSWORD")
+        .optopt("", "discovery-port", "Explicitly set TCP port used for discovery", "PORT")
         .optflag("", "disable-discovery", "Disable discovery mode")
         .optopt("", "backend", "Audio backend to use. Use '?' to list options", "BACKEND")
         .optopt("", "device", "Audio device to use. Use '?' to list options", "DEVICE")
@@ -145,6 +146,7 @@ fn setup(args: &[String]) -> Setup {
                                       cached_credentials);
 
     let enable_discovery = !matches.opt_present("disable-discovery");
+    let discovery_port = matches.opt_str("discovery-port").map(|x| x.parse::<u16>().expect("invalid port"));
 
     let config = Config {
         user_agent: version::version_string(),
@@ -152,6 +154,7 @@ fn setup(args: &[String]) -> Setup {
         bitrate: bitrate,
         onstart: matches.opt_str("onstart"),
         onstop: matches.opt_str("onstop"),
+        discovery_port: discovery_port
     };
 
     let device = matches.opt_str("device");
@@ -217,8 +220,9 @@ impl Main {
     fn discovery(&mut self) {
         let device_id = self.config.device_id.clone();
         let name = self.name.clone();
+        let discovery_port = self.config.discovery_port;
 
-        self.discovery = Some(discovery(&self.handle, name, device_id).unwrap());
+        self.discovery = Some(discovery(&self.handle, name, device_id, discovery_port).unwrap());
     }
 
     fn credentials(&mut self, credentials: Credentials) {

--- a/src/session.rs
+++ b/src/session.rs
@@ -49,6 +49,7 @@ pub struct Config {
     pub bitrate: Bitrate,
     pub onstart: Option<String>,
     pub onstop: Option<String>,
+    pub discovery_port: Option<u16>
 }
 
 impl Default for Config {
@@ -60,6 +61,7 @@ impl Default for Config {
             bitrate: Bitrate::Bitrate160,
             onstart: None,
             onstop: None,
+            discovery_port: None,
         }
     }
 }


### PR DESCRIPTION
Allow the user to specify the port used for the discovery service
manually, instead of it being chosen by the operating system.

This is useful when using an external mDNS responder, for example in a
setup where the clients and the librespot installation live in different
broadcast domains.