### PR TITLE
Make use of file cache for audio data optional - enabled by default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,9 @@ portaudio-backend = ["portaudio-rs"]
 pulseaudio-backend = ["libpulse-sys"]
 
 with-tremor = ["tremor"]
+with-audiocache = []
 
-default = ["portaudio-backend"]
+default = ["portaudio-backend","with-audiocache"]
 
 [package.metadata.deb]
 maintainer = "nobody"

--- a/src/audio_file.rs
+++ b/src/audio_file.rs
@@ -131,19 +131,19 @@ impl Future for AudioFileOpenStreaming {
 
 impl AudioFileManager {
     pub fn open(&self, file_id: FileId) -> AudioFileOpen {
-		#[cfg(feature = "with-audiocache")]
+        #[cfg(feature = "with-audiocache")]
         let cache = self.session().cache().cloned();
 
-		#[cfg(feature = "with-audiocache")] {
-			if let Some(file) = cache.as_ref().and_then(|cache| cache.file(file_id)) {
-				debug!("File {} already in cache", file_id);
-				return AudioFileOpen::Cached(future::ok(file));
-			}
+        #[cfg(feature = "with-audiocache")] {
+            if let Some(file) = cache.as_ref().and_then(|cache| cache.file(file_id)) {
+                debug!("File {} already in cache", file_id);
+                return AudioFileOpen::Cached(future::ok(file));
+            }
         }
 
         debug!("Downloading file {}", file_id);
 
-		#[allow(unused_variables)]
+        #[allow(unused_variables)]
         let (complete_tx, complete_rx) = oneshot::channel();
         let (headers, data) = request_chunk(&self.session(), file_id, 0).split();
 
@@ -157,10 +157,10 @@ impl AudioFileManager {
             complete_tx: Some(complete_tx),
         };
 
-		#[cfg(feature = "with-audiocache")]
+        #[cfg(feature = "with-audiocache")]
         let session = self.session();
         
-		#[cfg(feature = "with-audiocache")]
+        #[cfg(feature = "with-audiocache")]
         self.session().spawn(move |_| {
             complete_rx.map(move |mut file| {
                 if let Some(cache) = session.cache() {

--- a/src/audio_file.rs
+++ b/src/audio_file.rs
@@ -3,7 +3,9 @@ use byteorder::{ByteOrder, BigEndian, WriteBytesExt};
 use futures::Stream;
 use futures::sync::{oneshot, mpsc};
 use futures::{Poll, Async, Future};
-use futures::future::{self, FutureResult};
+#[cfg(feature = "with-audiocache")]
+use futures::future;
+use futures::future::FutureResult;
 use std::cmp::min;
 use std::fs;
 use std::io::{self, Read, Write, Seek, SeekFrom};
@@ -129,15 +131,19 @@ impl Future for AudioFileOpenStreaming {
 
 impl AudioFileManager {
     pub fn open(&self, file_id: FileId) -> AudioFileOpen {
+		#[cfg(feature = "with-audiocache")]
         let cache = self.session().cache().cloned();
 
-        if let Some(file) = cache.as_ref().and_then(|cache| cache.file(file_id)) {
-            debug!("File {} already in cache", file_id);
-            return AudioFileOpen::Cached(future::ok(file));
+		#[cfg(feature = "with-audiocache")] {
+			if let Some(file) = cache.as_ref().and_then(|cache| cache.file(file_id)) {
+				debug!("File {} already in cache", file_id);
+				return AudioFileOpen::Cached(future::ok(file));
+			}
         }
 
         debug!("Downloading file {}", file_id);
 
+		#[allow(unused_variables)]
         let (complete_tx, complete_rx) = oneshot::channel();
         let (headers, data) = request_chunk(&self.session(), file_id, 0).split();
 
@@ -151,7 +157,10 @@ impl AudioFileManager {
             complete_tx: Some(complete_tx),
         };
 
+		#[cfg(feature = "with-audiocache")]
         let session = self.session();
+        
+		#[cfg(feature = "with-audiocache")]
         self.session().spawn(move |_| {
             complete_rx.map(move |mut file| {
                 if let Some(cache) = session.cache() {


### PR DESCRIPTION
In some environments we have limited storage. Or we don't want the audio data to be cached because there's little use for it. Build librespot without the with-audiocache feature to disable storing of the audio data on your file system.