### PR TITLE
Fix #173 (a track cannot be played with librespot)

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -16,13 +16,19 @@ fn countrylist_contains(list: &str, country: &str) -> bool {
 fn parse_restrictions<'s, I>(restrictions: I, country: &str, catalogue: &str) -> bool
     where I: IntoIterator<Item = &'s protocol::metadata::Restriction>
 {
-    restrictions.into_iter()
-                .filter(|r| r.get_catalogue_str().contains(&catalogue.to_owned()))
-                .all(|r| {
-                    !countrylist_contains(r.get_countries_forbidden(), country) &&
-                    (!r.has_countries_allowed() ||
-                     countrylist_contains(r.get_countries_allowed(), country))
-                })
+    let mut forbidden = "".to_string();
+    let mut allowed = "".to_string();
+    let rs = restrictions.into_iter().filter(|r|
+        r.get_catalogue_str().contains(&catalogue.to_owned())
+    );
+
+    for r in rs {
+        forbidden.push_str(r.get_countries_forbidden());
+        allowed.push_str(r.get_countries_allowed());
+    }
+
+    (forbidden == "" || !countrylist_contains(forbidden.as_str(), country)) &&
+    (allowed == "" || countrylist_contains(allowed.as_str(), country))
 }
 
 pub trait MetadataTrait : Send + 'static {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -17,18 +17,29 @@ fn parse_restrictions<'s, I>(restrictions: I, country: &str, catalogue: &str) ->
     where I: IntoIterator<Item = &'s protocol::metadata::Restriction>
 {
     let mut forbidden = "".to_string();
+    let mut has_forbidden = false;
+
     let mut allowed = "".to_string();
+    let mut has_allowed = false;
+
     let rs = restrictions.into_iter().filter(|r|
         r.get_catalogue_str().contains(&catalogue.to_owned())
     );
 
     for r in rs {
-        forbidden.push_str(r.get_countries_forbidden());
-        allowed.push_str(r.get_countries_allowed());
+        if r.has_countries_forbidden() {
+            forbidden.push_str(r.get_countries_forbidden());
+            has_forbidden = true;
+        }
+
+        if r.has_countries_allowed() {
+            allowed.push_str(r.get_countries_allowed());
+            has_allowed = true;
+        }
     }
 
-    (forbidden == "" || !countrylist_contains(forbidden.as_str(), country)) &&
-    (allowed == "" || countrylist_contains(allowed.as_str(), country))
+    (!has_forbidden || !countrylist_contains(forbidden.as_str(), country)) &&
+    (!has_allowed || countrylist_contains(allowed.as_str(), country))
 }
 
 pub trait MetadataTrait : Send + 'static {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -38,6 +38,7 @@ fn parse_restrictions<'s, I>(restrictions: I, country: &str, catalogue: &str) ->
         }
     }
 
+    (has_forbidden || has_allowed) &&
     (!has_forbidden || !countrylist_contains(forbidden.as_str(), country)) &&
     (!has_allowed || countrylist_contains(allowed.as_str(), country))
 }


### PR DESCRIPTION
Some tracks might have several `allowed` fields, librespot assumes that all fields must match, otherwise track cannot be played.
This change collects all `allowed` and `forbidden` lists, then does the final check on whole lists at once.