### PR TITLE
Update system_information_string

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -41,7 +41,7 @@ pub fn authenticate(transport: Transport, credentials: Credentials, device_id: S
         system_info => {
             cpu_family: CpuFamily::CPU_UNKNOWN,
             os: Os::OS_UNKNOWN,
-            system_information_string: "librespot".to_string() + "_" + &(version::short_sha()) + "_" + &(version::short_now()),
+            system_information_string: format!("librespot-{}-{}", version::short_sha(), version::short_now()),
             device_id: device_id,
         },
         version_string: version::version_string(),

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -41,7 +41,7 @@ pub fn authenticate(transport: Transport, credentials: Credentials, device_id: S
         system_info => {
             cpu_family: CpuFamily::CPU_UNKNOWN,
             os: Os::OS_UNKNOWN,
-            system_information_string: "This is not the client you are looking for".to_owned(),
+            system_information_string: "librespot".to_string() + "_" + &(version::short_sha()) + "_" + &(version::short_now()),
             device_id: device_id,
         },
         version_string: version::version_string(),

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -41,7 +41,7 @@ pub fn authenticate(transport: Transport, credentials: Credentials, device_id: S
         system_info => {
             cpu_family: CpuFamily::CPU_UNKNOWN,
             os: Os::OS_UNKNOWN,
-            system_information_string: format!("librespot-{}-{}", version::short_sha(), version::short_now()),
+            system_information_string: format!("librespot_{}_{}", version::short_sha(), version::short_now()),
             device_id: device_id,
         },
         version_string: version::version_string(),


### PR DESCRIPTION
After speaking with Spotify about the previous blocking of librespot, Spotify has clarified that there aren't plans to block librespot again. They have however requested that the system_information_string be changed back to librespot so that they have a metric to view and measure interest in the standalone library.