### PR TITLE
Rust-Crypto fix for Intel "Westmere" CPU's

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ num-traits      = "0.1.36"
 protobuf        = "1.1"
 rand            = "0.3.13"
 rpassword       = "0.3.0"
-rust-crypto     = "0.2.34"
+rust-crypto     = { git = "https://github.com/awmath/rust-crypto.git", branch = "avx2" }
 serde           = "0.9.6"
 serde_json      = "0.9.5"
 serde_derive    = "0.9.6"


### PR DESCRIPTION
See https://github.com/DaGenix/rust-crypto/issues/390 for details.

As rust-crypto doesn't appear to getting regular fixes, this pull request changes where rust-crypto is built from, as suggest by @suluke suggest here: https://github.com/plietar/librespot/issues/155