### PR TITLE
pulseaudio: enable setting device

### DIFF
--- a/src/audio_backend/pulseaudio.rs
+++ b/src/audio_backend/pulseaudio.rs
@@ -12,7 +12,9 @@ impl Open for PulseAudioSink {
         debug!("Using PulseAudio sink");
 
         if device.is_some() {
-            panic!("pulseaudio sink does not support specifying a device name");
+            let sink = device.unwrap().as_ptr();
+        } else {
+            let sink = null()
         }
 
         let ss = pa_sample_spec {
@@ -28,7 +30,7 @@ impl Open for PulseAudioSink {
             pa_simple_new(null(),               // Use the default server.
                           name.as_ptr(),        // Our application's name.
                           PA_STREAM_PLAYBACK,
-                          null(),               // Use the default device.
+                          sink,
                           description.as_ptr(), // Description of our stream.
                           &ss,                  // Our sample format.
                           null(),               // Use default channel map


### PR DESCRIPTION
I would like to be able to specify a non-default pulseaudio device from the command line.
I have tried very hard, but failed.
Would someone here be so kind to give me a hint how to amend the code to use device if it is specified at the command line, and null otherwise.
Thank you in advance