### PR TITLE
Change system_information_string according to request from Spotify

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ tokio-signal = "0.1"
 uuid = { version = "0.4", features = ["v4"] }
 
 [build-dependencies]
+rand            = "0.3.13"
 vergen          = "0.1.0"
 protobuf_macros = { git = "https://github.com/plietar/rust-protobuf-macros", features = ["with-syntex"] }
 

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,42 @@
 extern crate vergen;
 extern crate protobuf_macros;
+extern crate rand;
 
+use rand::Rng;
 use std::env;
 use std::path::PathBuf;
+use std::fs::OpenOptions;
+use std::io::Write;
 
 fn main() {
-    vergen::vergen(vergen::OutputFns::all()).unwrap();
 
     let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    vergen::vergen(vergen::OutputFns::all()).unwrap();
+
+    let build_id: String = rand::thread_rng()
+        .gen_ascii_chars()
+        .take(8)
+        .collect();
+
+    let mut version_file =
+        OpenOptions::new()
+        .write(true)
+        .append(true)
+        .open(&out.join("version.rs"))
+        .unwrap();
+
+    let build_id_fn = format!("
+/// Generate a random build id.
+pub fn build_id() -> &'static str {{
+    \"{}\"
+}}
+", build_id);
+
+    if let Err(e) = version_file.write_all(build_id_fn.as_bytes()) {
+        println!("{}", e);
+    }
+
     protobuf_macros::expand("src/lib.in.rs", &out.join("lib.rs")).unwrap();
 
     println!("cargo:rerun-if-changed=src/lib.in.rs");

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -41,7 +41,7 @@ pub fn authenticate(transport: Transport, credentials: Credentials, device_id: S
         system_info => {
             cpu_family: CpuFamily::CPU_UNKNOWN,
             os: Os::OS_UNKNOWN,
-            system_information_string: "This is not the client you are looking for".to_owned(),
+            system_information_string: format!("librespot_{}_{}", version::short_sha(), version::build_id()),
             device_id: device_id,
         },
         version_string: version::version_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,10 +110,11 @@ fn setup(args: &[String]) -> Setup {
     let verbose = matches.opt_present("verbose");
     setup_logging(verbose);
 
-    info!("librespot {} ({}). Built on {}.",
+    info!("librespot {} ({}). Built on {}. Build ID: {}",
              version::short_sha(),
              version::commit_date(),
-             version::short_now());
+             version::short_now(),
+             version::build_id());
 
     let backend_name = matches.opt_str("backend");
     if backend_name == Some("?".into()) {


### PR DESCRIPTION
In communication with @sashahilton00, Spotify requested us to use a system_information_string that looks like ```librespot_[short sha]_[random 8 characters build id]```.

Original PR: #207

It extends ```version.rs```, which is generated by ```vergen```. The build script will only execute if there is no cache or the file changed - so generating a new ID (or version information) after the first build has to be done with ```cargo clean && cargo build```.

Of course pushing this or a similar functionality [upstream](https://github.com/rustyhorde/vergen) should be considered afterwards.