### PR TITLE
pause after last track has finished

### DIFF
--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -523,11 +523,13 @@ impl SpircTask {
         let current_index = self.state.get_playing_track_index();
         let new_index = (current_index + 1) % (self.state.get_track().len() as u32);
 
+        let was_last_track = current_index + 1 >= self.state.get_track().len() as u32;
+
         self.state.set_playing_track_index(new_index);
         self.state.set_position_ms(0);
         self.state.set_position_measured_at(now_ms() as u64);
 
-        self.load_track(true);
+        self.load_track(!was_last_track);
         self.notify(None);
     }
 


### PR DESCRIPTION
Currently, librespot plays endlessly: After the last track in a playlist/album it continues playing the first one.

This changes the behaviour to match the official Spotify client: The first track is loaded again, but the player is paused.

See #237 